### PR TITLE
Fix compile error from bad spacing in long lines to `apply`

### DIFF
--- a/processor/src/main/kotlin/com/autodsl/processor/internal/AutoDslParamGen.kt
+++ b/processor/src/main/kotlin/com/autodsl/processor/internal/AutoDslParamGen.kt
@@ -85,7 +85,7 @@ private fun createWithFun(
     return FunSpec.builder("with${paramName.capitalize()}")
         .addParameter(paramName, param.typeName)
         .returns(builderClassName)
-        .addStatement("return this.apply { this.$paramName = $paramName}")
+        .addStatement("return this.apply·{ this.$paramName = $paramName}")
 }
 
 private fun createPropertySpec(
@@ -206,7 +206,7 @@ private fun createCollectionData(
             ).build()
         )
         .returns(builderClassName)
-        .addStatement("this.$paramName = $collectionClassNameValue().apply { $BLOCK_FUN_NAME() }.$collectionFieldName")
+        .addStatement("this.$paramName = $collectionClassNameValue().apply·{ $BLOCK_FUN_NAME() }.$collectionFieldName")
         .addStatement("return this")
         .build()
 

--- a/processor/src/main/kotlin/com/autodsl/processor/internal/AutoDslParamGen.kt
+++ b/processor/src/main/kotlin/com/autodsl/processor/internal/AutoDslParamGen.kt
@@ -85,7 +85,7 @@ private fun createWithFun(
     return FunSpec.builder("with${paramName.capitalize()}")
         .addParameter(paramName, param.typeName)
         .returns(builderClassName)
-        .addStatement("return this.apply·{ this.$paramName = $paramName}")
+        .addStatement("return this.apply·{ this.$paramName·=·$paramName}")
 }
 
 private fun createPropertySpec(
@@ -206,7 +206,7 @@ private fun createCollectionData(
             ).build()
         )
         .returns(builderClassName)
-        .addStatement("this.$paramName = $collectionClassNameValue().apply·{ $BLOCK_FUN_NAME() }.$collectionFieldName")
+        .addStatement("this.$paramName·= $collectionClassNameValue().apply·{ $BLOCK_FUN_NAME() }.$collectionFieldName")
         .addStatement("return this")
         .build()
 

--- a/release-bintray.gradle
+++ b/release-bintray.gradle
@@ -1,5 +1,5 @@
 ext {
-    libraryVersion = '0.0.10'
+    libraryVersion = '0.0.11'
 
     def groupName = "io.github.juanchosaravia.autodsl"
     bintrayRepo = 'autodsl'

--- a/samples/android-autodsl/build.gradle
+++ b/samples/android-autodsl/build.gradle
@@ -2,7 +2,7 @@
 
 buildscript {
     ext.kotlin_version = '1.3.72'
-    ext.autodsl_version = '0.0.10'
+    ext.autodsl_version = '0.0.11'
     repositories {
         google()
         jcenter()


### PR DESCRIPTION
Minor change from `apply {` to `apply·{`, fixes compilation errors from bad line breaking. Sample issue [here](https://github.com/square/kotlinpoet/issues/598)

Also updated the version, could use a release.

BTW, been using this for quite a while now, a fine idea and very useful. Thanks for sharing  @juanchosaravia, 